### PR TITLE
Add R-specific resources

### DIFF
--- a/collections/_resources/r-packages.md
+++ b/collections/_resources/r-packages.md
@@ -1,0 +1,8 @@
+---
+title: R Packages (2e)
+link: https://r-pkgs.org/
+skills: [SP, LIBS]
+audience: [learn]
+---
+
+Learn how to create a package, the fundamental unit of shareable, reusable, and reproducible R code.

--- a/collections/_resources/r-universe.md
+++ b/collections/_resources/r-universe.md
@@ -1,0 +1,8 @@
+---
+title: R-universe
+link: https://ropensci.org/r-universe/
+skills: [SWREPOS, SP]
+audience: [learn]
+---
+
+R-universe is rOpenSci’s platform for improving publication and discovery of research software in R. It provides a CRAN-like repository (so users can just use `install.packages()`) where package binaries are built for all platforms (including WASM!).

--- a/collections/_resources/ropensci-r-package-guide.md
+++ b/collections/_resources/ropensci-r-package-guide.md
@@ -1,0 +1,7 @@
+---
+title: "rOpenSci Package: Development, Maintainence, and Peer Review"
+link: https://devguide.ropensci.org/
+skills: [SP, LIBS]
+audience: [learn]
+---
+A guide for best practices in developing, maintaining, and reviewing R packages.

--- a/collections/_resources/ropensci.md
+++ b/collections/_resources/ropensci.md
@@ -1,0 +1,8 @@
+---
+title: rOpenSci
+link: https://ropensci.org/
+skills: [LIBS, SWREPOS]
+audience: [learn]
+---
+
+rOpenSci is an organization that supports development and maintenance of R packages for the sciences. One can submit an R package for review and if accepted it will be migrated to the rOpenSci organization and be searchable through rOpenSci's website.  They also have an active Slack community and regular community calls and events.


### PR DESCRIPTION
Working on adding a few R-specific resources to various places in the competencies page including:

- [x] The rOpenSci package guide
- [x] Hadley Wickham's R Packages book
- [x] rOpenSci organization (does R package code review, manages maintenance of a collection of R packages)
- [x] r-universe (a place to publish R packages besides CRAN or Bioconductor)

Not entirely sure yet which skills each of these belong to.