### PR TITLE
Update skill codes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Resources are bundled into a [Jekyll collection](https://jekyllrb.com/docs/colle
 title: "Research Software Engineering with Python"
 link: https://merely-useful.tech/py-rse/index.html
 image: https://merely-useful.tech/py-rse/tugboats-800x600.jpg
-skills: [DOCBB, LIBS, SWREPOS, SRU, TEAM, PM]
+skills: [DOCBB, DIST, SWREPOS, SRU, TEAM, PM]
 audience: [learn, teach]
 ---
 An ebook that one can read from front to back, covering the shell and CLI tools, Git basics, Makefiles, Configuration files, as well as a bit of Teamwork, Testing, Error-Handling, and Packaging. The level is mostly basic (also for people that have barely any previous experience with programming), but covers a wide range of essential skills. While Python is in the name, this is not really required.
@@ -18,5 +18,5 @@ An ebook that one can read from front to back, covering the shell and CLI tools,
 - `title:` renders as a heading and URL title of that resource
 - `link:` is the main URL
 - `image:` is an optional featured image of that resource
-- `skills:` is a list of competencies discussed. Valid values are `DOCBB`, `LIBS`, `SWLC`, `SWREPOS`, `MOD`, `NEW`, `RC`, `SRU`, `SP`, `DOMREP`, `TEAM`, `TEACH`, `PM`, `USERS`.
+- `skills:` is a list of competencies discussed. Valid values are `SWLC`, `DOCBB`, `DIST`, `SWREPOS`, `MOD`, `NEW`, `RC`, `SRU`, `SP`, `DOMREP`, `TEAM`, `TEACH`, `PM`, `USERS`.
 - `audience:` is a list with values from `learn` and `teach`, focusing on the main perspective.

--- a/_pages/competencies.md
+++ b/_pages/competencies.md
@@ -19,6 +19,15 @@ The respective preprint is currently in extensive review from the RSE community.
 RSEs are Research **Software Engineers** and, as such, posess software engineering skills
 that allow them to create and maintain complex and FAIR (Findable, Accessible, Interoperable, and Reusable) research software.
 
+### Adapting to the software life-cycle (SWLC) <a name="SWLC"></a>
+
+{% assign resources = site.resources | where: "skills", "SWLC"  %}
+{% for resource in resources %}
+
+- [{{ resource.title }}]({{ resource.link }})
+
+{% endfor %}
+
 ### Creating documented code building blocks (DOCBB) <a name="DOCBB"></a>
 
 {% assign resources = site.resources | where: "skills", "DOCBB"  %}
@@ -28,18 +37,9 @@ that allow them to create and maintain complex and FAIR (Findable, Accessible, I
 
 {% endfor %}
 
-### Building distributable libraries (LIBS) <a name="LIBS"></a>
+### Building distributable software (DIST) <a name="DIST"></a>
 
-{% assign resources = site.resources | where: "skills", "LIBS"  %}
-{% for resource in resources %}
-
-- [{{ resource.title }}]({{ resource.link }})
-
-{% endfor %}
-
-### Adapting to the software life-cycle (SWLC) <a name="SWLC"></a>
-
-{% assign resources = site.resources | where: "skills", "SWLC"  %}
+{% assign resources = site.resources | where: "skills", "DIST"  %}
 {% for resource in resources %}
 
 - [{{ resource.title }}]({{ resource.link }})

--- a/collections/_resources/better-scientific-software.md
+++ b/collections/_resources/better-scientific-software.md
@@ -1,7 +1,7 @@
 ---
 title: "Better Scientific Software"
 link: https://bssw.io/
-skills: [DOCBB, LIBS, SWLC, SWREPOS, MOD, SRU, SP , TEACH, PM]
+skills: [DOCBB, DIST, SWLC, SWREPOS, MOD, SRU, SP , TEACH, PM]
 audience: [learn]
 ---
 Material all around writing better scientific software and beyond. See the [list of all BSSw resources](https://bssw.io/items).

--- a/collections/_resources/effective-computation-in-physics.md
+++ b/collections/_resources/effective-computation-in-physics.md
@@ -1,7 +1,7 @@
 ---
 title: "Effective Computation in Physics"
 link: https://www.oreilly.com/library/view/effective-computation-in/9781491901564/
-skills: [DOCBB, LIBS, SWLC, SWREPOS, MOD, SRU, SP, DOMREP]
+skills: [DOCBB, DIST, SWLC, SWREPOS, MOD, SRU, SP, DOMREP]
 audience: [learn]
 ---
 This O'REILLY book is a great resource that can be very useful for research software beyond Physics. The topics range from terminal, classes and objects, to deploying software, testing, debugging, and copyright.

--- a/collections/_resources/r-packages.md
+++ b/collections/_resources/r-packages.md
@@ -1,7 +1,7 @@
 ---
 title: R Packages (2e)
 link: https://r-pkgs.org/
-skills: [SP, LIBS]
+skills: [SP, DIST]
 audience: [learn]
 ---
 

--- a/collections/_resources/research-software-engineering-with-python.md
+++ b/collections/_resources/research-software-engineering-with-python.md
@@ -2,7 +2,7 @@
 title: "Research Software Engineering with Python"
 link: https://third-bit.com/py-rse/
 image: https://third-bit.com/py-rse/tugboats-800x600.jpg
-skills: [DOCBB, LIBS, SWREPOS, SRU, TEAM, PM]
+skills: [DOCBB, DIST, SWREPOS, SRU, TEAM, PM]
 audience: [learn, teach]
 ---
 An ebook that one can read from front to back, covering the shell and CLI tools, Git basics, Makefiles, Configuration files, as well as a bit of Teamwork, Testing, Error-Handling, and Packaging. The level is mostly basic (also for people that have barely any previous experience with programming), but covers a wide range of essential skills. While Python is in the name, this is not really required.

--- a/collections/_resources/ropensci-r-package-guide.md
+++ b/collections/_resources/ropensci-r-package-guide.md
@@ -1,7 +1,7 @@
 ---
 title: "rOpenSci Package: Development, Maintainence, and Peer Review"
 link: https://devguide.ropensci.org/
-skills: [SP, LIBS]
+skills: [SP, DIST]
 audience: [learn]
 ---
 A guide for best practices in developing, maintaining, and reviewing R packages.

--- a/collections/_resources/ropensci.md
+++ b/collections/_resources/ropensci.md
@@ -1,7 +1,7 @@
 ---
 title: rOpenSci
 link: https://ropensci.org/
-skills: [LIBS, SWREPOS]
+skills: [DIST, SWREPOS]
 audience: [learn]
 ---
 

--- a/collections/_resources/suresoft.md
+++ b/collections/_resources/suresoft.md
@@ -2,7 +2,7 @@
 title: Suresoft
 link: https://suresoft.dev
 image: https://suresoft.dev/site/img/branding/Suresoft_Logo.png
-skills: [DOCBB, LIBS, SWLC, SWREPOS, MOD, SRU, SP, PM]
+skills: [DOCBB, DIST, SWLC, SWREPOS, MOD, SRU, SP, PM]
 audience: [learn]
 ---
 


### PR DESCRIPTION
This updates the skill codes and the order of them according to v3 of the preprint: https://arxiv.org/abs/2311.11457

@Aariq thank you reporting this (closes #33). The only difference was the rename of `LIBS` to `DIST`. This was a simple renaming of the acronym, there are no further changes.

We could add descriptions to the skills after the respective peer-reviewed publication is through review, we just wanted to avoid duplication until things have converged.