### PR TITLE
fixed broken link

### DIFF
--- a/_pages/teach.md
+++ b/_pages/teach.md
@@ -6,7 +6,7 @@ layout: single
 toc: true
 ---
 
-Are teaching your own RSE courses? Are you trying to teach specific [skills](competencies)? These resources may help.
+Are teaching your own RSE courses? Are you trying to teach specific [skills]({{ site.baseurl }}/competencies)? These resources may help.
 
 [Contribute to this page](https://github.com/DE-RSE/learn-and-teach/blob/main/_pages/teach.md).
 


### PR DESCRIPTION
Hi there,

I found a dead link and _think_ this will fix it.

- currently, it links to https://de-rse.org/learn-and-teach/teach/competencies, which does not exist
- the link from the Learn-page to Competencies works

Feel free to close this PR, if you think it's unfitting.