### PR TITLE
Add links to GitHub and Zenodo community

### DIFF
--- a/index.md
+++ b/index.md
@@ -46,6 +46,8 @@ You can find here some _very good_ resources on teaching and learning RSE skills
 
 We aim for original and extensive resources, targetting both general-purpose RSEs, as well as RSE specializations.
 
+This collection is curated by the teachingRSE group. We organize ourselves on [GitHub](https://github.com/the-teachingRSE-project) and we publish outputs on our [Zenodo community](https://zenodo.org/communities/teachingrse).
+
 ## How to contribute?
 
 See the [contributing guidelines](https://github.com/DE-RSE/learn-and-teach/blob/main/CONTRIBUTING.md), or [open an issue](https://github.com/DE-RSE/learn-and-teach/issues).

--- a/index.md
+++ b/index.md
@@ -47,6 +47,8 @@ You can find here some _very good_ resources on teaching and learning RSE skills
 We aim for original and extensive resources, targetting both general-purpose RSEs, as well as RSE specializations.
 
 This collection is curated by the teachingRSE group. We organize ourselves on [GitHub](https://github.com/the-teachingRSE-project) and we publish outputs on our [Zenodo community](https://zenodo.org/communities/teachingrse).
+We communicate on [Matrix](https://matrix.to/#/#de-rse.org-AK-trainingRSE:matrix.org) and a [mailing list](https://www.listserv.dfn.de/sympa/info/jmu-teachingrse).
+If you are interested in joining our efforts, just drop in one of our meetings announced there.
 
 ## How to contribute?
 


### PR DESCRIPTION
I figured that we don't seem to have GitHub and Zenodo links here. This PR adds them on the main page.

@CaptainSifff do I overlook something? Would there be a better place?